### PR TITLE
Feature/gh templates

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,5 +1,32 @@
-#### Brief description/ PR title
+## Brief description/ PR title
 - Status: DNM/Ready for review
+
+### PR: develop -> master
+Brief summary of what changes are to be rolled out to live infrastructure
+
+#### Dependencies
+Description of other PRs/repos that are dependent on what has changed e.g. api.kent
+
+#### Deploy checklist
+##### Before deploy:
+- [ ] develop on the test server
+- [ ] any dependencies (other repos) on the test server
+- [ ] all changes tested on test server
+- [ ] necessary comms sent out to affected users
+- [ ] system booking is in place
+- [ ] config changes have been put onto live server (.env/config.php etc)
+
+##### After deploy:
+- [ ] All dependencies rolled out to live
+- [ ] Migrations run on live server
+- [ ] Seeds run on live server
+- [ ] Changes tested on live
+- [ ] System booking closed
+- [ ] Relevant FootPrints tickets responded to
+- [ ] Relevant Trello cards moved to done
+- [ ] Product owner/stakeholders updated (if no Trello/FP ticket)
+
+### PR: Feature branch -> develop
 - Trello: link to trello card *(if applicable)*
 - FootPrints: ticket number *(if applicable)*
 
@@ -23,6 +50,8 @@ git checkout <feature_branch>
 List general components of the application that this PR will affect
 
 #### Todos
+- [ ] Code follows [KentStandards](https://github.com/unikent/KentStandards)
+- [ ] Assets have been built & revisioned
 - [ ] Tests added
 - [ ] Tests passed
 - [ ] Documentation:

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,0 +1,31 @@
+#### Brief description/ PR title
+- Status: DNM/Ready for review
+- Trello: link to trello card *(if applicable)*
+- FootPrints: ticket number *(if applicable)*
+
+#### Related PRs
+List related PRs/branches
+
+#### Where should the reviewer start?
+Outline the steps to test or reproduce the PR here
+
+```
+git pull --prune
+git checkout <feature_branch>
+```
+
+- Necessary config changes
+- Any migrations/seeds to be run
+- Necessary corresponding PRs
+- How to access new/changed functionality
+
+#### Impacted Areas in Application
+List general components of the application that this PR will affect
+
+#### Todos
+- [ ] Tests added
+- [ ] Tests passed
+- [ ] Documentation:
+  - [ ] GitHub README.md updated
+  - [ ] Shire documents updated
+- [ ] Changes tested and working in supported browsers

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -27,6 +27,7 @@ Description of other PRs/repos that are dependent on what has changed e.g. api.k
 - [ ] Product owner/stakeholders updated (if no Trello/FP ticket)
 
 ### PR: Feature branch -> develop
+Brief summary of what changes have been made
 - Trello: link to trello card *(if applicable)*
 - FootPrints: ticket number *(if applicable)*
 


### PR DESCRIPTION
## Addition of GitHub Pull Request Template file
- Status: Ready for review

### PR: Feature branch -> develop
- To encourage us to document changes more I am experimenting with GH templates
- I have started with the most recent product we have been working on with the aim to roll out to other products as we see fit
- This should be seen as a work in progress - I welcome feedback as to what is most useful to record in the PR

- **Trello: https://trello.com/c/umyUSyej/545-spike-investigate-github-templates-for-prs**

#### Where should the reviewer start?
- Have a look at added file - .github/pull-request-template.md
- Review detail within md - is this enough/too much?
- Which repositories would having the PR template on be most useful? *Discussion point as a team*

#### Impacted Areas in Application
The codebase has not been changed, but once merged this change will affect any new Pull Requests. The template file serves as a basis for adding content to PRs to give a greater description for QA purposes.